### PR TITLE
use retryable http client

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,4 +34,7 @@ provider "seq" {
 ### Optional
 
 - **api_key** (String, Sensitive) The API Key to use when connecting to Seq. This can also be set with the `SEQ_API_KEY` environment variable.
+- **retry_max** (Number) The number of HTTP request retries.
+- **retry_wait_max** (Number) The maximum time in seconds to wait between HTTP request attempts.
+- **retry_wait_min** (Number) The minimum time in seconds to wait between HTTP request attempts.
 - **server_url** (String) The HTTP endpoint address of the Seq server. This can also be set with the `SEQ_SERVER_URL` environment variable.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
+	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/hashicorp/terraform-plugin-docs v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4
 	github.com/innovationnorway/go-seq v0.0.0-20210225123848-af7c33890e89

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,7 @@ github.com/hashicorp/go-getter v1.4.0/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUC
 github.com/hashicorp/go-getter v1.5.0 h1:ciWJaeZWSMbc5OiLMpKp40MKFPqO44i0h3uyfXPBkkk=
 github.com/hashicorp/go-getter v1.5.0/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.15.0 h1:qMuK0wxsoW4D0ddCCYwPSTm4KQv1X1ke3WmPWZ0Mvsk=
 github.com/hashicorp/go-hclog v0.15.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
@@ -192,6 +193,8 @@ github.com/hashicorp/go-plugin v1.3.0 h1:4d/wJojzvHV1I4i/rrjVaeuyxWrLzDE1mDCyDy8
 github.com/hashicorp/go-plugin v1.3.0/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYtXdgmf1AVNs0=
 github.com/hashicorp/go-plugin v1.4.0 h1:b0O7rs5uiJ99Iu9HugEzsM67afboErkHUWddUSpUO3A=
 github.com/hashicorp/go-plugin v1.4.0/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
+github.com/hashicorp/go-retryablehttp v0.6.8 h1:92lWxgpa+fF3FozM4B3UZtHZMJX8T5XT+TFdCxsPyWs=
+github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,8 +3,9 @@ package provider
 import (
 	"context"
 	"net/url"
+	"time"
 
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -31,6 +32,24 @@ func New(version string) func() *schema.Provider {
 					Sensitive:   true,
 					DefaultFunc: schema.EnvDefaultFunc("SEQ_API_KEY", nil),
 					Description: "The API Key to use when connecting to Seq. This can also be set with the `SEQ_API_KEY` environment variable.",
+				},
+				"retry_max": {
+					Type:        schema.TypeInt,
+					Optional:    true,
+					DefaultFunc: schema.EnvDefaultFunc("SEQ_HTTP_RETRY_MAX", 4),
+					Description: "The number of HTTP request retries.",
+				},
+				"retry_wait_min": {
+					Type:        schema.TypeInt,
+					Optional:    true,
+					DefaultFunc: schema.EnvDefaultFunc("SEQ_HTTP_RETRY_WAIT_MIN", 1),
+					Description: "The minimum time in seconds to wait between HTTP request attempts.",
+				},
+				"retry_wait_max": {
+					Type:        schema.TypeInt,
+					Optional:    true,
+					DefaultFunc: schema.EnvDefaultFunc("SEQ_HTTP_RETRY_WAIT_MAX", 30),
+					Description: "The maximum time in seconds to wait between HTTP request attempts.",
 				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{
@@ -63,9 +82,15 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 			return nil, diag.Errorf("error parsing host: %s", err)
 		}
 
+		r := retryablehttp.NewClient()
+		r.RetryMax = d.Get("retry_max").(int)
+		r.RetryWaitMin = time.Duration(d.Get("retry_wait_min").(int)) * time.Second
+		r.RetryWaitMax = time.Duration(d.Get("retry_wait_max").(int)) * time.Second
+		r.Logger = nil
+
 		config := seq.NewConfiguration()
 		config.UserAgent = p.UserAgent("terraform-provider-seq", version)
-		config.HTTPClient = cleanhttp.DefaultClient()
+		config.HTTPClient = r.StandardClient()
 		config.HTTPClient.Transport = logging.NewTransport("Seq", config.HTTPClient.Transport)
 		config.Host = u.Host
 		config.Scheme = u.Scheme


### PR DESCRIPTION
Adds support for setting `retry_max`, `retry_wait_min` and `retry_wait_max` in the provider configuration