### PR TITLE
seq_license: support for setting the `automatically_refresh` property

### DIFF
--- a/docs/resources/license.md
+++ b/docs/resources/license.md
@@ -27,11 +27,11 @@ resource "seq_license" "example" {
 
 ### Optional
 
+- **automatically_refresh** (Boolean) If the license is for a subscription, automatically check datalust.co and update the license when the subscription is renewed or tier changed.
 - **id** (String) The ID of this resource.
 
 ### Read-Only
 
-- **automatically_refresh** (Boolean) If the license is for a subscription, automatically check datalust.co and update the license when the subscription is renewed or tier changed.
 - **can_renew_online_now** (Boolean) If `true`, the license can be renewed online.
 - **is_single_user** (Boolean) If `true`, the server is using the default license which allows a single person to access the Seq server.
 - **is_valid** (Boolean) Whether or not the license is valid for the server.

--- a/internal/provider/resource_license.go
+++ b/internal/provider/resource_license.go
@@ -25,6 +25,12 @@ func resourceLicense() *schema.Resource {
 				Required:         true,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 			},
+			"automatically_refresh": {
+				Description: "If the license is for a subscription, automatically check datalust.co and update the license when the subscription is renewed or tier changed.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
 			"status_description": {
 				Description: "Information about the status of the license.",
 				Type:        schema.TypeString,
@@ -38,11 +44,6 @@ func resourceLicense() *schema.Resource {
 			"subscription_id": {
 				Description: "If the license is a subscription, the subscription id.",
 				Type:        schema.TypeString,
-				Computed:    true,
-			},
-			"automatically_refresh": {
-				Description: "If the license is for a subscription, automatically check datalust.co and update the license when the subscription is renewed or tier changed.",
-				Type:        schema.TypeBool,
 				Computed:    true,
 			},
 			"can_renew_online_now": {
@@ -78,6 +79,10 @@ func resourceLicenseCreateUpdate(ctx context.Context, d *schema.ResourceData, me
 	license := seq.License{
 		Id:          seq.PtrString(id),
 		LicenseText: d.Get("license_text").(string),
+	}
+
+	if v, ok := d.GetOk("automatically_refresh"); ok {
+		license.AutomaticallyRefresh = seq.PtrBool(v.(bool))
 	}
 
 	r, resp, err := client.LicensesApi.UpdateLicense(auth, id).License(license).Execute()


### PR DESCRIPTION
Adds support for setting the `automatically_refresh` property of the `seq_license` resource